### PR TITLE
feat: add prebuild support for easier installation

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -1,0 +1,130 @@
+name: Prebuild
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  prebuild-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [x64, arm64]
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libsimdjson-dev libomp-dev
+          npm ci
+      
+      - name: Build for Linux ${{ matrix.arch }}
+        run: |
+          npx prebuildify --napi --strip --arch=${{ matrix.arch }}
+      
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: prebuilds-linux-${{ matrix.arch }}
+          path: prebuilds/
+
+  prebuild-macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: [x64, arm64]
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      
+      - name: Install dependencies
+        run: |
+          brew install simdjson libomp
+          npm ci
+      
+      - name: Build for macOS ${{ matrix.arch }}
+        run: |
+          npx prebuildify --napi --strip --arch=${{ matrix.arch }}
+      
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: prebuilds-macos-${{ matrix.arch }}
+          path: prebuilds/
+
+  prebuild-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: [x64]
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      
+      - name: Install dependencies
+        run: |
+          # Install vcpkg for simdjson
+          git clone https://github.com/Microsoft/vcpkg.git C:\vcpkg
+          C:\vcpkg\bootstrap-vcpkg.bat
+          C:\vcpkg\vcpkg install simdjson:x64-windows
+          npm ci
+      
+      - name: Build for Windows ${{ matrix.arch }}
+        run: |
+          $env:VCPKG_ROOT = "C:\vcpkg"
+          npx prebuildify --napi --strip --arch=${{ matrix.arch }}
+      
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: prebuilds-windows-${{ matrix.arch }}
+          path: prebuilds/
+
+  package:
+    needs: [prebuild-linux, prebuild-macos, prebuild-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: prebuilds-*
+          merge-multiple: true
+          path: prebuilds/
+      
+      - name: List prebuilds
+        run: find prebuilds -type f -name "*.node" | sort
+      
+      - name: Package for release
+        run: |
+          tar -czf prebuilds.tar.gz prebuilds/
+      
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: prebuilds.tar.gz
+          draft: false
+          prerelease: false

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,40 @@
+# Source files (we ship the built binary)
+src/*.o
+src/test_*
+src/Makefile
+
+# Build artifacts (but keep prebuilds/)
+build/
+!prebuilds/
+*.log
+.DS_Store
+
+# Test data
+test/
+out/
+out_embedded/
+cpp_std_embedded/
+cpp_std_embeddings/
+cpp_std_partitioned/
+test_data/
+*.bin
+benchmark_results.txt
+
+# Development files
+.env
+.env.local
+*.dSYM/
+**/*.dSYM/
+CLAUDE.md
+.claude_context/
+
+# Git
+.git/
+.gitignore
+
+# Other
+docs/
+scripts/generate_embeddings.js
+scripts/partition_cpp_docs.js
+embed_dir.js
+test_doc.json

--- a/PUBLISH_CHECKLIST.md
+++ b/PUBLISH_CHECKLIST.md
@@ -1,0 +1,71 @@
+# NPM Publishing Checklist
+
+## Pre-publish Steps
+
+1. **Update package.json**
+   - [ ] Set correct version number (follow semver)
+   - [ ] Update author information
+   - [ ] Verify license is correct
+
+2. **Test Everything**
+   ```bash
+   npm run clean
+   npm run build
+   npm test
+   ```
+
+3. **Check what will be published**
+   ```bash
+   npm pack --dry-run
+   ```
+   This shows all files that will be included in the package.
+
+4. **Verify native dependencies**
+   - Ensure simdjson is documented as a system requirement
+   - OpenMP requirements are clear
+
+## Publishing
+
+1. **Login to npm** (if not already)
+   ```bash
+   npm login
+   ```
+
+2. **Publish to npm**
+   ```bash
+   npm publish
+   ```
+
+   For first release or if the package name is taken:
+   ```bash
+   npm publish --access public
+   ```
+
+## Post-publish
+
+1. **Verify installation works**
+   ```bash
+   # In a different directory
+   npm install native-vector-store
+   ```
+
+2. **Test the published package**
+   ```javascript
+   const { VectorStore } = require('native-vector-store');
+   const store = new VectorStore(1536);
+   console.log('Success!');
+   ```
+
+## Important Notes
+
+- The package requires system dependencies (simdjson, OpenMP)
+- Users need to have build tools installed for compilation
+- Consider using prebuildify for prebuilt binaries in the future
+
+## System Requirements Documentation
+
+Make sure README clearly states:
+- C++17 compatible compiler required
+- simdjson library must be installed
+- OpenMP support required
+- Node.js 14+ required

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ npm install native-vector-store
 
 ### Prerequisites
 
+For most users, **no prerequisites are needed** - prebuilt binaries are included for:
+- Linux (x64, arm64)
+- macOS (x64, arm64/Apple Silicon)
+- Windows (x64)
+
+If building from source, you'll need:
 - Node.js ≥14.0.0
 - C++ compiler with OpenMP support
 - simdjson library (automatically handled by node-gyp)

--- a/docs/PREBUILDS.md
+++ b/docs/PREBUILDS.md
@@ -1,0 +1,69 @@
+# Prebuilt Binaries
+
+This package includes prebuilt binaries for common platforms to make installation easier. Users don't need build tools or system dependencies when installing from npm if their platform is supported.
+
+## Supported Platforms
+
+Prebuilds are automatically created for:
+- **Linux**: x64, arm64
+- **macOS**: x64, arm64 (including Apple Silicon)
+- **Windows**: x64
+
+## How It Works
+
+1. When users run `npm install native-vector-store`, the install script uses `node-gyp-build`
+2. `node-gyp-build` checks if a prebuild exists for the current platform
+3. If found, it uses the prebuild (fast, no compilation needed)
+4. If not found, it falls back to building from source
+
+## Building Prebuilds
+
+### Locally (for current platform)
+```bash
+npm run prebuildify
+```
+
+### For all platforms (using GitHub Actions)
+1. Push a tag starting with 'v' (e.g., v0.1.0)
+2. GitHub Actions will automatically build for all platforms
+3. Prebuilds will be attached to the GitHub release
+
+### Manual trigger
+You can also manually trigger the prebuild workflow from the Actions tab on GitHub.
+
+## Including Prebuilds in npm Package
+
+The prebuilds are automatically included when you run `npm publish`. The directory structure is:
+```
+native-vector-store/
+├── prebuilds/
+│   ├── linux-x64/
+│   ├── linux-arm64/
+│   ├── darwin-x64/
+│   ├── darwin-arm64/
+│   └── win32-x64/
+└── ... other files
+```
+
+## Fallback Behavior
+
+If a prebuild isn't available, users will need:
+- C++17 compatible compiler
+- simdjson library
+- OpenMP support
+- Python and build tools
+
+## Testing Prebuilds
+
+After building prebuilds:
+```bash
+# Test that it loads correctly
+node -e "console.log(require('.'))"
+```
+
+## Troubleshooting
+
+If prebuilds aren't working:
+1. Check that `node-gyp-build` is in dependencies (not devDependencies)
+2. Ensure prebuilds/ directory is not in .npmignore
+3. Verify the binary names match node-gyp-build expectations

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-const { VectorStore } = require('./build/Release/vector_store');
+const { VectorStore } = require('node-gyp-build')(__dirname);
 
 module.exports = { VectorStore };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,14 +7,26 @@
     "": {
       "name": "native-vector-store",
       "version": "0.1.0",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
       "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
       "dependencies": {
         "dotenv": "^17.2.0",
         "node-addon-api": "^7.0.0",
+        "node-gyp-build": "^4.8.0",
         "openai": "^5.8.3"
       },
       "devDependencies": {
-        "node-gyp": "^10.0.0"
+        "node-gyp": "^10.0.0",
+        "prebuildify": "^6.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -146,6 +158,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -154,6 +199,31 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/cacache": {
@@ -313,6 +383,16 @@
         "iconv-lite": "^0.6.2"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -353,6 +433,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fs-minipass": {
       "version": "3.0.3",
@@ -444,6 +531,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -463,6 +571,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "9.0.5",
@@ -573,6 +688,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -734,6 +859,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -749,6 +881,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.75.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-addon-api": {
@@ -782,6 +927,17 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/nopt": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
@@ -796,6 +952,29 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+      "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/openai": {
@@ -869,6 +1048,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/prebuildify": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/prebuildify/-/prebuildify-6.0.1.tgz",
+      "integrity": "sha512-8Y2oOOateom/s8dNBsGIcnm6AxPmLH4/nanQzL5lQMU+sC0CMhzARZHizwr36pUPLdvBnOkCNQzxg4djuFSgIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "mkdirp-classic": "^0.5.3",
+        "node-abi": "^3.3.0",
+        "npm-run-path": "^3.1.0",
+        "pump": "^3.0.0",
+        "tar-fs": "^2.1.0"
+      },
+      "bin": {
+        "prebuildify": "bin.js"
+      }
+    },
     "node_modules/proc-log": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
@@ -893,6 +1090,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -902,6 +1125,27 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1019,6 +1263,16 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -1143,6 +1397,43 @@
         "node": ">=10"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -1204,6 +1495,13 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "4.0.0",
@@ -1318,6 +1616,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "arm64"
       ],
       "hasInstallScript": true,
-      "license": "MIT",
+      "license": "Apache 2.0",
       "os": [
         "darwin",
         "linux",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,23 @@
   "description": "High-performance vector store with SIMD optimization for MCP servers",
   "main": "index.js",
   "types": "lib/index.d.ts",
+  "author": "Your Name <your.email@example.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mboros1/native-vector-store.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mboros1/native-vector-store/issues"
+  },
+  "homepage": "https://github.com/mboros1/native-vector-store#readme",
   "scripts": {
     "build": "node-gyp rebuild",
     "clean": "node-gyp clean",
     "test": "node test/test.js",
-    "install": "node-gyp rebuild",
-    "prepack": "npm run build",
+    "install": "node-gyp-build",
+    "prebuildify": "prebuildify --napi --strip",
+    "prebuildify-cross": "prebuildify-cross -i centos7-devtoolset7 -i alpine -i linux-arm64 -i darwin-arm64 -i darwin-x64+arm64",
     "benchmark": "node test/test.js",
     "example": "node examples/mcp-server.js demo",
     "embed": "node embed_dir.js"
@@ -25,11 +36,15 @@
   "dependencies": {
     "dotenv": "^17.2.0",
     "node-addon-api": "^7.0.0",
+    "node-gyp-build": "^4.8.0",
     "openai": "^5.8.3"
   },
   "devDependencies": {
-    "node-gyp": "^10.0.0"
+    "node-gyp": "^10.0.0",
+    "prebuildify": "^6.0.0"
   },
+  "os": ["darwin", "linux", "win32"],
+  "cpu": ["x64", "arm64"],
   "engines": {
     "node": ">=14.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "native-vector-store",
   "version": "0.1.0",
-  "description": "High-performance vector store with SIMD optimization for MCP servers",
+  "description": "High-performance local vector store with SIMD optimization for MCP servers",
   "main": "index.js",
   "types": "lib/index.d.ts",
-  "author": "Your Name <your.email@example.com>",
-  "license": "MIT",
+  "author": "Martin Boros <mboros04@gmail.com>",
+  "license": "Apache 2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mboros1/native-vector-store.git"

--- a/scripts/build-prebuilds.sh
+++ b/scripts/build-prebuilds.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Build prebuilds for current platform
+echo "Building prebuilds for native-vector-store..."
+
+# Clean previous builds
+rm -rf prebuilds/
+
+# Build for current platform and architecture
+echo "Building for current platform..."
+npx prebuildify --napi --strip
+
+# For local testing on macOS, build both architectures if on Apple Silicon
+if [[ "$OSTYPE" == "darwin"* ]] && [[ "$(uname -m)" == "arm64" ]]; then
+    echo "Building universal binary for macOS..."
+    npx prebuildify --napi --strip --arch x64
+    npx prebuildify --napi --strip --arch arm64
+fi
+
+echo "Prebuilds created:"
+find prebuilds -type f -name "*.node" | sort
+
+echo "Done!"


### PR DESCRIPTION
- Added prebuildify for creating prebuilt binaries
- Set up GitHub Actions workflow to build for all platforms
- Updated to use node-gyp-build for automatic prebuild detection
- Added documentation for prebuild process
- Users no longer need build tools for supported platforms

Supported platforms:
- Linux (x64, arm64)
- macOS (x64, arm64/Apple Silicon)
- Windows (x64)

Falls back to building from source if prebuild not available.

🤖 Generated with [Claude Code](https://claude.ai/code)